### PR TITLE
Make cabal-graphdeps more flexible and improve documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+Comparison with other Haskell dependency graphers
+=================================================
+
+The `cabal-db` package is more versatile than `cabal-graphdeps`, but
+only works with hackage packages, whereas `cabal-graphdeps` also works
+with local packages. The `stack dot` command does finer grained
+depencency resolution than `cabal-graphdeps` -- namely, `stack dot`
+shows the exact dependency structure whereas `cabal-graphdeps` shows
+the transitive closure of the exact dependency structure -- but the
+`cabal-graphdeps` package lets you override the Haskell tool chain
+more easily. You'll probably want to pipe the output of
+`cabal-graphdeps` through the Dot program `tred` to eliminate edges
+implied by transitivity.
+
+Examples
+========
+
+In the simplest case, just tell `cabal-graphdeps` what package to
+compute deps for. For example,
+
+    cabal-graphdeps cabal-graphdeps
+
+will produce a graph of all non-`base` dependencies of itself.
+
+On the other hand, a more complicated package called `prattle` might
+have local non-Hackage dependencies, need extra Cabal configuration
+(e.g. flags), and depend on a special Haskell tool chain (here
+HaLVM). For example,
+
+    cabal-graphdeps --cabal halvm-cabal --ghc-pkg halvm-ghc-pkg --add-sources .,hsntp,ssh-hans,ssh-hans-chatter --cabal-config halvm-cabal-sandbox/cabal.config --use-all-global-packages prattle
+
+Run `cabal-graphdeps --help` for a full list of available options.

--- a/cabal-graphdeps.cabal
+++ b/cabal-graphdeps.cabal
@@ -1,5 +1,5 @@
 name: cabal-graphdeps
-version: 0.1.3
+version: 0.2.0
 license: MIT
 license-file: license.txt
 author: John Millikin <john@john-millikin.com>
@@ -11,8 +11,10 @@ stability: experimental
 homepage: https://john-millikin.com/software/cabal-graphdeps/
 bug-reports: mailto:jmillikin@gmail.com
 
-synopsis: Generate graphs of install-time Cabal dependencies
-description:
+synopsis: Generate Dot graphs of install-time Cabal dependencies
+description: Generate Dot graphs of install-time Cabal dependencies.
+
+extra-soure-files: README.md
 
 source-repository head
   type: git

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -153,9 +153,11 @@ initSandbox opts = do
 			rawGlobalDb <- Process.readProcess "ghc-pkg" ["list", "--no-user-package-db"] ""
 			case lines rawGlobalDb of
 				firstLine:_ ->
-					-- ghc-pkg adds a ':' to the first line when not
+					-- Some versions of ghc-pkg adds a ':' to the first line when not
 					-- run from a terminal
-					return (reverse (drop 1 (reverse firstLine)))
+					if last firstLine == ':'
+					then return (init firstLine)
+					else return firstLine
 				_ -> error "Unexpected output from ghc-pkg list"
 		path -> return path
 	

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -27,6 +27,10 @@ data MainOptions = MainOptions
 	{ optGlobalPackageDb :: String
 	, optFundamental :: [String]
 	, optExclude :: Set.Set String
+	, optCabal :: String
+	, optGhcPkg :: String
+	, optAddSources :: [FilePath]
+	, optCabalConfig :: Maybe FilePath
 	}
 
 instance Options MainOptions where
@@ -43,6 +47,26 @@ instance Options MainOptions where
 			, optionDefault = Set.empty
 			, optionDescription = "These comma-separated packages and their dependencies will be excluded when rendering the graph."
 			})
+		<*> defineOption optionType_string (\o -> o
+			{ optionLongFlags = ["cabal"]
+			, optionDefault = "cabal"
+			, optionDescription = "The name of or path to the cabal executable."
+			})
+		<*> defineOption optionType_string (\o -> o
+			{ optionLongFlags = ["ghc-pkg"]
+			, optionDefault = "ghc-pkg"
+			, optionDescription = "The name of or path to the ghc-pkg executable."
+			})
+		<*> defineOption (optionType_list ',' optionType_string) (\o -> o
+			{ optionLongFlags = ["add-sources"]
+			, optionDefault = []
+			, optionDescription = "These comma-separated paths to local packages will be added to the Cabal sandbox with 'cabal sandbox add-source'."
+			})
+		<*> defineOption (optionType_maybe optionType_string) (\o -> o
+			{ optionLongFlags = ["cabal-config"]
+			, optionDefault = Nothing
+			, optionDescription = "The path to a 'cabal.config' file, e.g. to specify constraints."
+			})
 
 resolveDeps :: MainOptions -> Map.Map String (Set.Set String) -> String -> IO (Map.Map String (Set.Set String))
 resolveDeps _ allDeps pkg | Map.member pkg allDeps = return allDeps
@@ -52,7 +76,7 @@ resolveDeps opts allDeps pkg = do
 	let header2 = "Resolving dependencies...\nIn order, the following would be installed:\n"
 	
 	IO.hPutStrLn IO.stderr ("[" ++ pkg ++ "]")
-	output <- Process.readProcess "cabal" ["--package-db=clear", "install", "--dry-run", "--ghc-pkg-options=--global-package-db=./empty-db", pkg] ""
+	output <- Process.readProcess (optCabal opts) ["--package-db=clear", "install", "--dry-run", "--ghc-pkg-options=--global-package-db=./empty-db", pkg] ""
 	if "All the requested packages are already installed:" `isInfixOf` output
 		then return allDeps
 		else do
@@ -132,9 +156,9 @@ extractPkgName pkg = case stripPrefix "-" (dropWhile (/= '-') (reverse pkg)) of
 printDeps :: MainOptions -> Map.Map String (Set.Set String) -> String -> IO ()
 printDeps opts deps pkg = forM_ (Set.toAscList (renderDeps opts deps pkg)) putStrLn
 
-readGhcPkgField :: String -> String -> IO String
-readGhcPkgField pkgName fieldName = do
-	rawField <- Process.readProcess "ghc-pkg" ["field", pkgName, fieldName] ""
+readGhcPkgField :: MainOptions -> String -> String -> IO String
+readGhcPkgField opts pkgName fieldName = do
+	rawField <- Process.readProcess (optGhcPkg opts) ["field", pkgName, fieldName] ""
 	case stripPrefix (fieldName ++ ":") rawField of
 		Nothing -> error ("Unexpected output from ghc-pkg field: " ++ show rawField)
 		Just s -> return (dropWhile isSpace (dropWhileEnd isSpace s))
@@ -144,13 +168,15 @@ dropWhileEnd p = foldr (\x xs -> if p x && null xs then [] else x : xs) []
 
 initSandbox :: MainOptions -> IO ()
 initSandbox opts = do
-	_ <- Process.readProcess "cabal" ["sandbox", "init"] ""
+	_ <- Process.readProcess (optCabal opts) ["sandbox", "init"] ""
+	forM_ (optAddSources opts) $ \path ->
+		Process.readProcess (optCabal opts) ["sandbox", "add-source", path] ""
 	Filesystem.createDirectory "empty-db"
 	
 	globalDb <- case optGlobalPackageDb opts of
 		-- Look for the global package DB
 		"" -> do
-			rawGlobalDb <- Process.readProcess "ghc-pkg" ["list", "--no-user-package-db"] ""
+			rawGlobalDb <- Process.readProcess (optGhcPkg opts) ["list", "--no-user-package-db"] ""
 			case lines rawGlobalDb of
 				firstLine:_ ->
 					-- Some versions of ghc-pkg adds a ':' to the first line when not
@@ -165,13 +191,13 @@ initSandbox opts = do
 	-- graph for being fundamental.
 	forM_ (optFundamental opts) $ \pkg -> do
 		-- find package id (used in .conf filename)
-		pkgId <- readGhcPkgField pkg "id"
+		pkgId <- readGhcPkgField opts pkg "id"
 		let pkgConf = pkgId ++ ".conf"
 		
 		-- try to figure out what the package depends on; in the GHC
 		-- installed on my system, ::depends includes all dependencies
 		-- of the package.
-		deps <- readGhcPkgField pkg "depends"
+		deps <- readGhcPkgField opts pkg "depends"
 		let splitDeps = words deps
 		let emptyPackageDbConfs = pkgConf : [s ++ ".conf" | s <- splitDeps]
 		forM_ emptyPackageDbConfs $ \conf -> Filesystem.copyFile (globalDb ++ "/" ++ conf) ("empty-db/" ++ conf)
@@ -192,8 +218,19 @@ main = runCommand $ \opts args -> do
 		_ -> do
 			IO.hPutStrLn IO.stderr "Usage: cabal-graphdeps <package-name>"
 			exitFailure
+	-- Make all paths in the options absolute because we're about to cd
+	-- into a temp dir.
+	opts <- do
+		let addSources = optAddSources opts
+		let cabalConfig = optCabalConfig opts
+		absoluteAddSources <- mapM Filesystem.makeAbsolute addSources
+		absoluteCabalConfig <- mapM Filesystem.makeAbsolute cabalConfig
+		return (opts { optAddSources = absoluteAddSources, optCabalConfig = absoluteCabalConfig })
 	deps <- withSystemTempDirectory "cabal-graphdeps.d-" $ \dir -> withCurrentDirectory dir $ do
 		initSandbox opts
+		case optCabalConfig opts of
+			Nothing -> return ()
+			Just path -> Filesystem.copyFile path "cabal.config"
 		resolveDeps opts Map.empty rootPackageName
 	putStrLn "digraph {"
 	printDeps opts deps rootPackageName

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -3,7 +3,7 @@
 -- License: MIT
 --
 -- Run like:
--- >$ cabal-graphdeps mypackage | tred | dot -Tpng > ~/mypackage.png
+-- >$ cabal-graphdeps <mypackage> | tred | dot -Tpng > ~/<mypackage>.png
 module Main where
 
 import           Control.Applicative
@@ -36,12 +36,12 @@ instance Options MainOptions where
 		<*> defineOption (optionType_list ',' optionType_string) (\o -> o
 			{ optionLongFlags = ["fundamental-packages"]
 			, optionDefault = ["base"]
-			, optionDescription = "These packages and their dependencies should be considered fundamental to the package DB."
+			, optionDescription = "These comma-separated packages and their dependencies must already be installed."
 			})
 		<*> defineOption (optionType_set ',' optionType_string) (\o -> o
 			{ optionLongFlags = ["exclude-packages"]
 			, optionDefault = Set.empty
-			, optionDescription = "These packages and their dependencies will be excluded when rendering the graph."
+			, optionDescription = "These comma-separated packages and their dependencies will be excluded when rendering the graph."
 			})
 
 resolveDeps :: MainOptions -> Map.Map String (Set.Set String) -> String -> IO (Map.Map String (Set.Set String))


### PR DESCRIPTION
I had a complicated use case that I edited `cabal-graphdeps` for. I ended up getting better results in the end by editing the Stack tool, but I think my changes improve `cabal-graphdeps` in any case, and so you might want to merge them.

The most controversial change is probably that I renamed `--fundamental-packages` to `--global-packages`, but the word "fundamental" doesn't mean anything to me here, and it seems that operationally that option specifies which packages should be assumed already available from the global package db.

I attempted to improve the documentation of the individual options, and add a README, in hopes of making it easier for future users of `cabal-graphdeps`.